### PR TITLE
use json parser to load data, remove whitespace, javascript object style

### DIFF
--- a/flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
+++ b/flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
@@ -14,6 +14,7 @@ import yaml
 import zlib
 import xml.etree.ElementTree as ET
 import json
+from addict import Dict
 
 from flexbe_core import Logger
 
@@ -346,9 +347,8 @@ class VigirBeOnboard(object):
         result = dict()
 
         for k, v in zip(keys, values):
-            result[k] = json.loads(v)
+            result[k] = _convert_dict(json.loads(v))
         return result
-
 
 
     def _build_contains(self, obj, path):
@@ -369,3 +369,11 @@ class VigirBeOnboard(object):
         while True:
             self._pub.publish('flexbe/heartbeat', Empty())
             time.sleep(1) # sec
+
+def _convert_dict(o):
+    if isinstance(o, list):
+        return [_convert_dict(e) for e in o]
+    elif isinstance(o, dict):
+        return Dict({k: _convert_dict(v) for k, v in o.items()})
+    else:
+        return o

--- a/flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
+++ b/flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
@@ -382,6 +382,6 @@ class VigirBeOnboard(object):
         if isinstance(o, list):
             return [self._convert_dict(e) for e in o]
         elif isinstance(o, dict):
-            return self._attr_dict(o)
+            return self._attr_dict((k, self._convert_dict(v)) for k, v in o.items())
         else:
             return o

--- a/flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
+++ b/flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
@@ -13,6 +13,7 @@ import random
 import yaml
 import zlib
 import xml.etree.ElementTree as ET
+import json
 
 from flexbe_core import Logger
 
@@ -98,7 +99,7 @@ class VigirBeOnboard(object):
         self._pub.publish(self.status_topic, BEStatus(code=BEStatus.READY))
         rospy.loginfo('\033[92m--- Behavior Engine ready! ---\033[0m')
 
-        
+
     def _behavior_callback(self, msg):
         thread = threading.Thread(target=self._behavior_execution, args=[msg])
         thread.daemon = True
@@ -243,7 +244,7 @@ class VigirBeOnboard(object):
             Logger.logerr('Exception caught in behavior definition:\n%s' % str(e))
             self._pub.publish(self.status_topic, BEStatus(behavior_id=msg.behavior_checksum, code=BEStatus.ERROR))
             return
-        
+
         # import contained behaviors
         contain_list = {}
         try:
@@ -251,7 +252,7 @@ class VigirBeOnboard(object):
         except Exception as e:
             Logger.logerr('Failed to load contained behaviors:\n%s' % str(e))
             return
-            
+
         # initialize behavior parameters
         if len(msg.arg_keys) > 0:
             rospy.loginfo('The following parameters will be used:')
@@ -259,7 +260,7 @@ class VigirBeOnboard(object):
             for i in range(len(msg.arg_keys)):
                 if msg.arg_keys[i] == '':
                     # action call has empty string as default, not a valid param key
-                    continue 
+                    continue
                 key_splitted = msg.arg_keys[i].rsplit('/', 1)
                 if len(key_splitted) == 1:
                     behavior = ''
@@ -269,7 +270,7 @@ class VigirBeOnboard(object):
                     behavior = key_splitted[0]
                     key = key_splitted[1]
                 found = False
-                
+
                 if behavior == '' and hasattr(be, key):
                     self._set_typed_attribute(be, key, msg.arg_values[i])
                     # propagate to contained behaviors
@@ -282,8 +283,8 @@ class VigirBeOnboard(object):
                     if b == behavior and hasattr(contain_list[b], key):
                         self._set_typed_attribute(contain_list[b], key, msg.arg_values[i], b)
                         found = True
-                            
-                if not found:   
+
+                if not found:
                     rospy.logwarn('Parameter ' + msg.arg_keys[i] + ' (set to ' + msg.arg_values[i] + ') not implemented')
 
         except Exception as e:
@@ -303,7 +304,7 @@ class VigirBeOnboard(object):
 
         return be
 
-     
+
     def _is_switchable(self, be):
         if self.be.name != be.name:
             Logger.logerr('Unable to switch behavior, names do not match:\ncurrent: %s <--> new: %s' % (self.be.name, be.name))
@@ -322,8 +323,8 @@ class VigirBeOnboard(object):
         del(sys.modules["tmp_%d" % behavior_checksum])
         file_path = os.path.join(self._tmp_folder, 'tmp_%d.pyc' % behavior_checksum)
         os.remove(file_path)
-        
-        
+
+
     def _set_typed_attribute(self, obj, name, value, behavior=''):
         attr = getattr(obj, name)
         if type(attr) is int:
@@ -342,31 +343,13 @@ class VigirBeOnboard(object):
 
 
     def _convert_input_data(self, keys, values):
-        # there is no reliable clean way to check type conversion in Python
         result = dict()
-        for k,v in zip(keys, values):
-            result[k] = v
-            try:
-                result[k] = int(v)
-                continue
-            except ValueError:
-                pass
-            try:
-                result[k] = float(v)
-                continue
-            except ValueError:
-                pass
-            if v.lower() == 'false':
-                result[k] = False
-                continue
-            if v.lower() == 'true':
-                result[k] = True
-                continue
-            if len(v) >= 2 and v[0] == '[' and v[-1] == ']':
-                result[k] = v[1:-1].split(',')
+
+        for k, v in zip(keys, values):
+            result[k] = json.loads(v)
         return result
 
-        
+
 
     def _build_contains(self, obj, path):
         contain_list = dict((path+"/"+key,value) for (key,value) in getattr(obj, 'contains', {}).items())
@@ -386,14 +369,3 @@ class VigirBeOnboard(object):
         while True:
             self._pub.publish('flexbe/heartbeat', Empty())
             time.sleep(1) # sec
-
-
-
-
-
-
-
-
-
-
-        


### PR DESCRIPTION
Use json as the transport for userdata for behavior execution actions. Also converts the nested dict that json.loads() emits into a nested javascript-style object, which means that states using the userdata can treat it like ROS messages of the correct type. I.e. something expecting a point_list of geometry_msgs/Point(s) can do point_list[0].z instead of point_list[0]['z'].

However, this adds a dependency on the python lib addict https://github.com/mewwts/addict.