### PR TITLE
reset entering of currently active state when exiting a state machine

### DIFF
--- a/flexbe_core/src/flexbe_core/core/operatable_state_machine.py
+++ b/flexbe_core/src/flexbe_core/core/operatable_state_machine.py
@@ -365,5 +365,6 @@ class OperatableStateMachine(PreemptableStateMachine):
                 self._current_state.get_registered_output_keys(),
                 self._remappings[self._current_state.name]
             )
+            self._current_state._entering = True
             self._current_state.on_exit(ud)
             self._current_state = None


### PR DESCRIPTION
Hi there,

I had an issue with a state being in a state machine container inside a concurrent container. This concurrency got called multiple times. A simplified version is depicted below:

![image](https://cloud.githubusercontent.com/assets/491645/22298857/4a7615c8-e322-11e6-911c-2fc2b04213d6.png)

Now, when the **preemption_listener** stops the **concurrency**, the **do_action**-state gets preempted (which is great), and we continue with **do_some_more_stuff**

After some intermediate states we get back to our concurrency and then it gets exited immediately saying that **do_action** is preempted.

After digging for a while it turns out, that *on_enter* of the **do_action** state does not get called in the second run. The **concurrency** sets the *_entering* member inside the **StateMachine** container, and this exits the currently active state (which is **do_action**), but it doesn't reset the *_entering* member of **do_action**, so it gets skipped the next time the state is visited.

Is this behavior intentional or was it simply forgotten there? This pull request resets the  *_entering* member for the currently active state on a state-machine exit. If this is somehow not desired, then please reject this PR, maybe with a clarification on why that is the case.

Cheers
Felix
