### PR TITLE
Update to the new flexbe app

### DIFF
--- a/flexbe_widget/launch/behavior_ocs.launch
+++ b/flexbe_widget/launch/behavior_ocs.launch
@@ -16,7 +16,7 @@
 <node name="behavior_rosapi" pkg="rosapi" type="rosapi_node" output="screen">
 	<param name="namespace" value="$(arg ns)" />
 </node>
-<node name="behavior_flexbe" pkg="flexbe_widget" type="flexbe_app" output="screen"  />
+<node name="behavior_flexbe" pkg="flexbe_app" type="run_app" output="screen"  />
 <node name="behavior_launcher" pkg="flexbe_widget" type="be_launcher" output="screen" >
 	<param name="behaviors_package" value="$(arg behaviors_package)"/>
 </node>


### PR DESCRIPTION
Updating the launch file to launch the correct new app.

By the way [the tutorial](http://wiki.ros.org/flexbe/Tutorials/Execution%20of%20a%20Behavior) says to execute: 
```
roslaunch flexbe_onboard behavior_testing.launch
[behavior_testing.launch] is neither a launch file in package [flexbe_onboard] nor is [flexbe_onboard] a launch file name
```

Which I found out the correct command is:

    roslaunch flexbe_onboard behavior_onboard.launch

I didn't want to change the wiki as you haven't migrated yet to the new app I guess.