### PR TITLE
feat: Add flexbe_behavior_engine metapackage

### DIFF
--- a/flexbe_behavior_engine/CMakeLists.txt
+++ b/flexbe_behavior_engine/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(flexbe_behavior_engine)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/flexbe_behavior_engine/package.xml
+++ b/flexbe_behavior_engine/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>flexbe_behavior_engine</name>
+  <version>1.0.0</version>
+  <description>
+    A meta-package to aggregate all the Flexbe packages
+  </description>
+
+  <maintainer email="alireza.mixedreality@gmail.com">Alireza Hosseini</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>flexbe_core</exec_depend>
+  <exec_depend>flexbe_input</exec_depend>
+  <exec_depend>flexbe_mirror</exec_depend>
+  <exec_depend>flexbe_msgs</exec_depend>
+  <exec_depend>flexbe_onboard</exec_depend>
+  <exec_depend>flexbe_states</exec_depend>
+  <exec_depend>flexbe_testing</exec_depend>
+  <exec_depend>flexbe_widget</exec_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+</package>


### PR DESCRIPTION
## What I did
- Added a **metapackage** to aggregate all the **FLEXBE** packages.
- It will be useful for distributing the Flexbe ROS packages as Debian packages, in a way that all the required packages will be simply installed by just installing this metapackage.

## How I tested
- By compiling the package
