### PR TITLE
flexbe_states: create symlink to behavior and state sources in installed package path

### DIFF
--- a/flexbe_states/CMakeLists.txt
+++ b/flexbe_states/CMakeLists.txt
@@ -25,6 +25,14 @@ catkin_package(
 #install(PROGRAMS bin/hello
 #        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
+install(CODE "
+  file(MAKE_DIRECTORY \"$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/src\")
+  execute_process(COMMAND
+    \"${CMAKE_COMMAND}\" -E create_symlink \"../../../${CATKIN_PACKAGE_PYTHON_DESTINATION}\"
+                                           \"$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/src/${PROJECT_NAME}\"
+  )
+")
+
 # run tests
 if(CATKIN_ENABLE_TESTING)
 	find_package(rostest REQUIRED)


### PR DESCRIPTION
I had to add this cmake snippet to the `flexbe_states` package and also to all our custom state and behavior packages to fix an error message in the FlexBE App when running from install-space:

```
Setting up ROS connection...
Checking 257 ROS packages for states and behaviors...
ROS connection running!


Parsing sourcecode...
Code parsing completed.
Building behavior state machine...
Unable to find state definition for: CheckConditionState
Please check your workspace settings.
Unable to find state definition for: CalculationState
Please check your workspace settings.
Unable to find state definition for: FlexibleServiceCallerState
Please check your workspace settings.
```

Another alternative is to always install an additional copy of the `src` folder to the package dir (`${CATKIN_PACKAGE_SHARE_DESTINATION}`), independent of the files installed to `lib/`.

A better approach would be to patch the FlexBE App such that it can find the source code using python:
```
$ python -c 'import flexbe_states; print(flexbe_states.__path__)'
['/path/to/install/space/lib/python2.7/dist-packages/flexbe_states']
```
or relative to the package path:
```
$ echo $(rospack find flexbe_states)/../../lib/python2.7/dist-packages/flexbe_states
/path/to/install/space/share/flexbe_states/../../lib/python2.7/dist-packages/flexbe_states
```
But I don't know enough about JavaScript and the underlying mechanics to propose such a patch. The relevant code seems to be in [src/io/io_packageparser.js](https://github.com/FlexBE/flexbe_app/blob/develop/src/io/io_packageparser.js).

It does not make sense to modify behaviors in an install-space or if the sources are not writable by the current user, e.g. because they are owned by root. But I assume the FlexBE App would still need to find the sources in order to only run a behavior. It would be a nice-to-have that the respective controls ("Statemachine Editor", "Save Behavior", ...) are disabled in those cases.