### PR TITLE
feat: Add `wait_duration` parameter to `ProxyActionClient`

### DIFF
--- a/flexbe_core/src/flexbe_core/proxy/proxy_action_client.py
+++ b/flexbe_core/src/flexbe_core/proxy/proxy_action_client.py
@@ -18,17 +18,21 @@ class ProxyActionClient(object):
     _result = {}
     _feedback = {}
 
-    def __init__(self, topics = {}):
+    def __init__(self, topics={}, wait_duration=10):
         """
         Initializes the proxy with optionally a given set of clients.
         
         @type topics: dictionary string - message class
         @param topics: A dictionay containing a collection of topic - message type pairs.
+
+        @type wait_duration: int
+        @param wait_duration: Defines how long to wait for each client in the
+            given set to become available (if it is not already available).
         """
 
         for topic, msg_type in topics.iteritems():
-            self.setupClient(topic, msg_type)
-    
+            self.setupClient(topic, msg_type, wait_duration)
+
 
     def setupClient(self, topic, msg_type, wait_duration=10):
         """


### PR DESCRIPTION
## What I did

This PR adds the possibility to set the waiting duration of `ProxyActionClient` (`wait_for_server`) from the flexbe states definition.