### PR TITLE
Fix issues of installed packages

### DIFF
--- a/flexbe_onboard/package.xml
+++ b/flexbe_onboard/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>flexbe_onboard</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>
      flexbe_onboard implements the robot-side of the behavior engine from where all behaviors are started.
   </description>

--- a/flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
+++ b/flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
@@ -52,7 +52,7 @@ class VigirBeOnboard(object):
 
         # prepare temp folder
         rp = rospkg.RosPack()
-        self._tmp_folder = os.path.join(rp.get_path('flexbe_onboard'), 'tmp/')
+        self._tmp_folder = "/tmp/flexbe_onboard"
         if not os.path.exists(self._tmp_folder):
             os.makedirs(self._tmp_folder)
         sys.path.append(self._tmp_folder)


### PR DESCRIPTION
Fix ~two~ one issues we had when installing the packages:

1. flexbe_onboard: Do not store temporary files inside the package directory but in `/tmp`. This is needed since the package directory is not writeable without root permission when the package is installed.
2. ~flexbe_states: Install the states src directory to share destination. Needed so that the FlexBE App can find the states (note that the files will not be executed from there, the "real" files are installed via the `setup.py`).~