### PR TITLE
Added remove_feedback function to ensure new feedback is received

### DIFF
--- a/flexbe_core/src/flexbe_core/proxy/proxy_action_client.py
+++ b/flexbe_core/src/flexbe_core/proxy/proxy_action_client.py
@@ -136,6 +136,15 @@ class ProxyActionClient(object):
         """
         return ProxyActionClient._feedback[topic]
 
+    def remove_feedback(self, topic):
+        """
+        Removes the latest feedback message of the given action call.
+
+        @type topic: string
+        @param topic: The topic of interest.
+        """
+        ProxyActionClient._feedback[topic] = None
+
     def get_state(self, topic):
         """
         Determines the current actionlib state of the given action topic.


### PR DESCRIPTION
Hi,
I noticed that the feedback message from proxy_action_client is not being cleared after getting it. So I added this optional function to remove the feedback message, somewhat analogous to  [remove_last_message](https://github.com/team-vigir/flexbe_behavior_engine/blob/master/flexbe_core/src/flexbe_core/proxy/proxy_subscriber_cached.py#L166) from proxy_subscriber_cached.

Please, review this change and merge if OK.

Thanks!

 