### PR TITLE
add remove_result function to proxy action client

### DIFF
--- a/flexbe_core/src/flexbe_core/proxy/proxy_action_client.py
+++ b/flexbe_core/src/flexbe_core/proxy/proxy_action_client.py
@@ -122,6 +122,15 @@ class ProxyActionClient(object):
         """
         return ProxyActionClient._result[topic]
 
+    def remove_result(self, topic):
+        """
+        Removes the latest result message of the given action call.
+
+        @type topic: string
+        @param topic: The topic of interest.
+        """
+        ProxyActionClient._result[topic] = None
+
     def has_feedback(self, topic):
         """
         Checks if the given action call has any feedback.


### PR DESCRIPTION
Similar to #62, I found that proxy action client's 'has_result()' function always return true after I used the result.
For example, in the execute function below,

``` python
def execute(self, userdata):
    if self.ac.has_result(self.topic):
        res = self.ac.get_result(self.topic)
        ...
```
I already used result. but the 'if' statement always activated everytime execute() function called because result is not cleared..

so I think adding remove_result function is needed