### PR TITLE
Fix formatting error that crashes behavior construction

### DIFF
--- a/flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
+++ b/flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
@@ -344,7 +344,7 @@ class VigirBeOnboard(object):
                 # unquoted strings will raise a ValueError, so leave it as string in this case
                 result[k] = str(v)
             except SyntaxError as se:
-                Logger.logwarn('Unable to parse input value for key "%s", assuming string:\n%s\%s', k, str(v), str(se))
+                Logger.logwarn('Unable to parse input value for key "%s", assuming string:\n%s\n%s' % (k, str(v), str(se)))
                 result[k] = str(v)
 
         return result


### PR DESCRIPTION
In certain cases if an input key has a weird value (such as '0_degree') it can cause an exception that prevents the behavior from being built. This is due to incorrect formatting in a warning message. This fixes the warning message formatting