### PR TITLE
Fix evaluate_logs usage string: default log path now "~/.flexbe_logs"

### DIFF
--- a/flexbe_widget/bin/evaluate_logs
+++ b/flexbe_widget/bin/evaluate_logs
@@ -13,9 +13,9 @@ if __name__ == '__main__':
 
 	if len(sys.argv) < 4:
 		print "Usage:"
-		print "> rosrun flexbe_widget evaluate_logs [logfile] [key] [value1, value2, ...]"
+		print "> rosrun flexbe_widget evaluate_logs [logfile] [key] [value1 value2 ...]"
 		print ""
-		print '- logfile: One of the logged files in ~/logs.'
+		print ' - logfile: One of the logged files in "~/.flexbe_logs".'
 		print '           Use an empty string ("") for latest file.'
 		print " - key:    One of the following keys:"
 		print "           total, state_path, state_name, state_class, transition"


### PR DESCRIPTION
Also corrects usage string whitespace, removes "," from value list.

Side-Note: The paragraph about evaluate_logs here is quite out of date:
http://philserver.bplaced.net/fbe/documentation.php