### PR TITLE
Fail test if provided test-yaml-file does not exist

### DIFF
--- a/flexbe_testing/bin/testing_node
+++ b/flexbe_testing/bin/testing_node
@@ -20,18 +20,17 @@ if __name__ == '__main__':
 		for arg in sys.argv[1:]:
 			if not arg.startswith('-') and not arg.startswith('_'):
 				testfile_path = os.path.expanduser(arg)
-				if os.path.isfile(testfile_path):
-					filenames.append(testfile_path)
-				else:
-					rospy.logerr("No such file: {}".format(testfile_path))
-					exit(1)
+				filenames.append(testfile_path)
 
 	tester = StateTester()
 
 	test_cases = dict()
 	for filename in filenames:
-		name, config = tester.configure_test(filename)
-		test_cases[name] = config
+		try:
+			name, config = tester.configure_test(filename)
+			test_cases[name] = config
+		except IOError as io_error:
+			rospy.logerr(io_error)
 
 	perform_rostest = rospy.get_param('~perform_rostest', False)
 	test_package = rospy.get_param('~package')

--- a/flexbe_testing/bin/testing_node
+++ b/flexbe_testing/bin/testing_node
@@ -18,8 +18,13 @@ if __name__ == '__main__':
 	if len(sys.argv) > 1:
 		print 'Loading provided test cases...'
 		for arg in sys.argv[1:]:
-			if os.path.isfile(os.path.expanduser(arg)):
-				filenames.append(os.path.expanduser(arg))
+			if not arg.startswith('-') and not arg.startswith('_'):
+				testfile_path = os.path.expanduser(arg)
+				if os.path.isfile(testfile_path):
+					filenames.append(testfile_path)
+				else:
+					rospy.logerr("No such file: {}".format(testfile_path))
+					exit(1)
 
 	test_cases = dict()
 	for filename in filenames:

--- a/flexbe_testing/bin/testing_node
+++ b/flexbe_testing/bin/testing_node
@@ -26,11 +26,11 @@ if __name__ == '__main__':
 					rospy.logerr("No such file: {}".format(testfile_path))
 					exit(1)
 
+	tester = StateTester()
+
 	test_cases = dict()
 	for filename in filenames:
-		with open(filename, 'r') as f:
-			config = yaml.load(f)
-		(folder, name) = os.path.split(filename)
+		name, config = tester.configure_test(filename)
 		test_cases[name] = config
 
 	perform_rostest = rospy.get_param('~perform_rostest', False)
@@ -40,7 +40,6 @@ if __name__ == '__main__':
 		rospy.logerr('Need to pass the name of the package under testing as arg "package" to the flexbe_testing launch file!')
 
 	print 'Ready for testing! (%d tests)' % len(test_cases)
-	tester = StateTester()
 
 	success_cases = 0
 	for test_name, test_config in test_cases.iteritems():

--- a/flexbe_testing/src/flexbe_testing/state_tester.py
+++ b/flexbe_testing/src/flexbe_testing/state_tester.py
@@ -45,7 +45,8 @@ class StateTester(object):
 				config = yaml.load(f)
 			return name, config
 		except IOError:
-			self._evaluation_tests['test_%s_config' % name.split('.')[0]] = self._test_pass(False)
+			self._evaluation_tests['test_%s_config' % name.split('.')[0]] = self._test_file_missing(filename)
+			raise
 
 	def run_test(self, name, config):
 		if self._mute_info:
@@ -260,4 +261,9 @@ class StateTester(object):
 	def _test_pass(self, passed):
 		def _test_call(test_self):
 			test_self.assertTrue(passed, "State did not pass flexbe tests.")
+		return _test_call
+
+	def _test_file_missing(self, path):
+		def _test_call(test_self):
+			test_self.fail("Test file {} does not exist".format(path))
 		return _test_call

--- a/flexbe_testing/src/flexbe_testing/state_tester.py
+++ b/flexbe_testing/src/flexbe_testing/state_tester.py
@@ -10,6 +10,7 @@ import roslaunch
 import unittest
 import rosunit
 import traceback
+import yaml
 
 from flexbe_core.core.loopback_state import LoopbackState
 
@@ -37,6 +38,14 @@ class StateTester(object):
 			self._mute_warn = True
 			self._mute_error = False
 
+	def configure_test(self, filename):
+		folder, name = os.path.split(filename)
+		try:
+			with open(filename, 'r') as f:
+				config = yaml.load(f)
+			return name, config
+		except IOError:
+			self._evaluation_tests['test_%s_config' % name.split('.')[0]] = self._test_pass(False)
 
 	def run_test(self, name, config):
 		if self._mute_info:


### PR DESCRIPTION
There is no way to know which arguments to `testing_node` are intended to be filenames, so best we can do is guess...

When a file is missing, there is also some test-output generated telling which file is missing. 