### PR TITLE
Retry reading bag file messages without backslash in unit tests

### DIFF
--- a/flexbe_testing/src/flexbe_testing/data_provider.py
+++ b/flexbe_testing/src/flexbe_testing/data_provider.py
@@ -32,7 +32,10 @@ class DataProvider(object):
             # message data
             if (isinstance(value, basestring) and len(value) > 1 and value[0] == '/' and value[1] != '/' and
                     self._bag is not None):
-                (_, result, _) = list(self._bag.read_messages(topics=[value]))[0]
+                try:
+                    (_, result, _) = list(self._bag.read_messages(topics=[value]))[0]
+                except IndexError:
+                    (_, result, _) = list(self._bag.read_messages(topics=[value[1:]]))[0]
             # anonymous function
             elif isinstance(value, basestring) and value.startswith('lambda '):
                 result = eval(value)


### PR DESCRIPTION
## Description

This small fix addresses the case where the bag file specified for unit testing contains topics without a forward slash (`/`). If such a (legal) bag is used, currently the following error is returned:
```
    unable to parse value "/trajectory" (will be considered as string):
	list index out of range
```

The IndexError occurs because supplying the topic with forward slash returns the empty list. In the case that the user specified a non-existing topic, another IndexError will be raised as expected.

## Testing

The following code produces a bag file that fails with current code and succeeds with this PR:

```
#!/usr/bin/env python
import rosbag

from trajectory_msgs.msg import JointTrajectory

bag = rosbag.Bag('test_some_state.bag', 'w')

try:
    jt = JointTrajectory()
    bag.write('trajectory', jt)  # succeeds when using '/trajectory

finally:
    bag.close()
```