### PR TITLE
Let behavior library find sourcecode in devel or install spaces

### DIFF
--- a/flexbe_core/src/flexbe_core/behavior_library.py
+++ b/flexbe_core/src/flexbe_core/behavior_library.py
@@ -14,7 +14,7 @@ Created on 10.01.2017
 
 class BehaviorLibrary(object):
 	'''
-	Provides a list of all known behavior manifests.
+	Provides access to all known behaviors.
 	'''
 
 	def __init__(self):
@@ -111,7 +111,32 @@ class BehaviorLibrary(object):
 		@return Number of behaviors.
 		"""
 		return len(self._behavior_lib)
+	
 
+	def get_sourcecode_filepath(self, be_id, add_tmp=False):
+		"""
+		Constructs a file path to the source code of corresponding to the given ID.
+
+		@type be_id: int
+		@param be_id: Behavior ID to look up.
+
+		@type add_tmp: bool
+		@param add_tmp: Append "_tmp" to the file to consider a temporary version.
+
+		@return String containing the absolute path to the source code file.
+		"""
+		be_entry = self.get_behavior(be_id)
+		if be_entry is None:
+			# rely on get_behavior to handle/log missing package
+			return None
+		try:
+			module_path = __import__(be_entry["package"]).__path__[-1]
+		except ImportError:
+			rospy.logwarn("Cannot import behavior package '%s', using 'rospack find' instead" % be_entry["package"])
+			# rp can find it because otherwise, the above entry would not exist
+			module_path = os.path.join(self._rp.get_path(be_entry["package"]), "src", be_entry["package"])
+		filename = be_entry["file"] + '.py' if not add_tmp else '_tmp.py'
+		return os.path.join(module_path, filename)
 
 
 

--- a/flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
+++ b/flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
@@ -172,12 +172,12 @@ class VigirBeOnboard(object):
             behavior = self._behavior_lib.get_behavior(msg.behavior_id)
             if behavior is None:
                 raise ValueError(msg.behavior_id)
-            be_filepath = os.path.join(rp.get_path(behavior["package"]), 'src/' + behavior["package"] + '/' + behavior["file"] + '_tmp.py')
+            be_filepath = self._behavior_lib.get_sourcecode_filepath(msg.behavior_id, add_tmp=True)
             if os.path.isfile(be_filepath):
                 be_file = open(be_filepath, "r")
                 rospy.logwarn("Found a tmp version of the referred behavior! Assuming local test run.")
             else:
-                be_filepath = os.path.join(rp.get_path(behavior["package"]), 'src/' + behavior["package"] + '/' + behavior["file"] + '.py')
+                be_filepath = self._behavior_lib.get_sourcecode_filepath(msg.behavior_id)
                 be_file = open(be_filepath, "r")
             be_content = be_file.read()
             be_file.close()

--- a/flexbe_widget/src/flexbe_widget/behavior_action_server.py
+++ b/flexbe_widget/src/flexbe_widget/behavior_action_server.py
@@ -82,11 +82,11 @@ class BehaviorActionServer(object):
 		be_selection.input_values = goal.input_values
 
 		# check for local modifications of the behavior to send them to the onboard behavior
-		be_filepath_new = os.path.join(self._rp.get_path(behavior["package"]), 'src/' + behavior["package"] + '/' + behavior["file"] + '.py')
+		be_filepath_new = self._behavior_lib.get_sourcecode_filepath(be_id)
 		with open(be_filepath_new, "r") as f:
 			be_content_new = f.read()
 
-		be_filepath_old = os.path.join(self._rp.get_path(behavior["package"]), 'src/' + behavior["package"] + '/' + behavior["file"] + '_tmp.py')
+		be_filepath_old = self._behavior_lib.get_sourcecode_filepath(be_id, add_tmp=True)
 		if not os.path.isfile(be_filepath_old):
 			be_selection.behavior_checksum = zlib.adler32(be_content_new)
 		else:

--- a/flexbe_widget/src/flexbe_widget/behavior_launcher.py
+++ b/flexbe_widget/src/flexbe_widget/behavior_launcher.py
@@ -74,7 +74,7 @@ class BehaviorLauncher(object):
 		be_structure.containers = msg.structure
 
 		try:
-			be_filepath_new = os.path.join(self._rp.get_path(behavior["package"]), 'src/' + behavior["package"] + '/' + behavior["file"] + '.py')
+			be_filepath_new = self._behavior_lib.get_sourcecode_filepath(be_id)
 		except ResourceNotFound:
 			rospy.logerr("Could not find behavior package '%s'" % (behavior["package"]))
 			rospy.loginfo("Have you updated your ROS_PACKAGE_PATH after creating the behavior?")
@@ -83,7 +83,7 @@ class BehaviorLauncher(object):
 		with open(be_filepath_new, "r") as f:
 			be_content_new = f.read()
 
-		be_filepath_old = os.path.join(self._rp.get_path(behavior["package"]), 'src/' + behavior["package"] + '/' + behavior["file"] + '_tmp.py')
+		be_filepath_old = self._behavior_lib.get_sourcecode_filepath(be_id, add_tmp=True)
 		if not os.path.isfile(be_filepath_old):
 			be_selection.behavior_checksum = zlib.adler32(be_content_new)
 			if msg.autonomy_level != 255:


### PR DESCRIPTION
Extend the behavior library to find sourcecode files for behaviors.
Based on the input from #106 and code used by the FlexBE App for finding behaviors, the function should now support both devel and install spaces.