### PR TITLE
Using event based action server instead of control loop.

### DIFF
--- a/flexbe_widget/src/flexbe_widget/behavior_action_server.py
+++ b/flexbe_widget/src/flexbe_widget/behavior_action_server.py
@@ -41,7 +41,7 @@ class BehaviorActionServer(object):
 
 
 	def _goal_cb(self):
-		if not self._as.is_new_goal_available():
+		if self._as.is_active() or not self._as.is_new_goal_available():
 			return
 		goal = self._as.accept_new_goal()
 		rospy.loginfo('Received a new request to start behavior: %s' % goal.behavior_name)
@@ -141,12 +141,12 @@ class BehaviorActionServer(object):
 			result = msg.args[0] if len(msg.args) >= 1 else ''
 			rospy.loginfo('Finished behavior execution with result "%s"!' % result)
 			self._as.set_succeeded(BehaviorExecutionResult(outcome=result))
+			# Call goal cb in case there is a queued goal available
+			self._goal_cb()
 		elif msg.code == BEStatus.FAILED:
 			rospy.logerr('Behavior execution failed in state %s!' % str(self._current_state))
 			self._as.set_aborted('')
-
-		# Start new goal if available and current is not active anymore
-		if not self._as.is_active() and self._as.is_new_goal_available():
+			# Call goal cb in case there is a queued goal available
 			self._goal_cb()
 
 


### PR DESCRIPTION
Prevents a race condition as mentioned in #117 by waiting until behavior execution is done.
Is there a reason why the server just set its goal to preempted after a short delay rather than waiting until the status changed to a terminal state?

Additionally, I rewrote the action server implementation to be callback-based instead of using a control loop.
This significantly simplifies the code and reduces latency because data is now processed as it comes in instead of having to wait until the control loop executes the next time.