### PR TITLE
Optionally fail test if launch-file fails

### DIFF
--- a/flexbe_testing/src/flexbe_testing/test_context.py
+++ b/flexbe_testing/src/flexbe_testing/test_context.py
@@ -13,7 +13,7 @@ class Callback(roslaunch.pmon.ProcessListener):
         self._callback = callback
 
     def process_died(self, process_name, exit_code):
-        rospy.loginfo("{}, {}".format(process_name, exit_code))
+        rospy.loginfo("Process {} exited with {}".format(process_name, exit_code))
         self._callback(process_name, exit_code)
 
 

--- a/flexbe_testing/src/flexbe_testing/tester.py
+++ b/flexbe_testing/src/flexbe_testing/tester.py
@@ -92,6 +92,9 @@ class Tester(object):
                     self._tests['test_%s_pass' % name] = self._test_pass(False)
                     return 0
 
+                if config.get('require_launch_success', False):
+                    context.wait_for_finishing()
+
             # evaluate outcome
             self._tests['test_%s_outcome' % name] = self._test_outcome(outcome, config['outcome'])
             outcome_ok = outcome == config['outcome']

--- a/flexbe_testing/src/flexbe_testing/tester.py
+++ b/flexbe_testing/src/flexbe_testing/tester.py
@@ -114,6 +114,11 @@ class Tester(object):
                 else:
                     Logger.print_negative('no result for %s' % expected_key)
                     output_ok = False
+
+            if not context.success and config.get('require_launch_success', False):
+                Logger.print_negative('Launch file did not exit cleanly')
+                output_ok = False
+
             if len(expected) > 0 and output_ok:
                 Logger.print_positive('all result outputs match expected')
 


### PR DESCRIPTION
If the launch-file in a FlexBE test fails, signal this to the TestContext that can then optionally fail due to this
This allows to run scripts etc to verify State/Behavior side effects



This is handy when combined with eg. https://github.com/ipa320/cob_command_tools/tree/indigo_dev/scenario_test_tools but simpler scripts as well of course. 

Together, this implements
> Check external effects in flexbe_testing, e.g. setting a rosparam or calling an action.

from https://github.com/team-vigir/flexbe_behavior_engine/issues/93