### PR TITLE
Debug/concurrent container test

### DIFF
--- a/flexbe_core/src/flexbe_core/core/concurrency_container.py
+++ b/flexbe_core/src/flexbe_core/core/concurrency_container.py
@@ -49,7 +49,12 @@ class ConcurrencyContainer(OperatableStateMachine):
                     # this sleep returns immediately since sleep duration is negative,
                     # but is required here to reset the sleep time after executing
                     state.sleep()
+
+            Logger.loginfo("BEFORE: state.sleep_duration({ssd}) if sleep_dur({sd}) is None else "
+                           "min(sleep_dur, state.sleep_duration)({m})"
+                           .format(ssd=state.sleep_duration, sd=sleep_dur, m=min(sleep_dur, state.sleep_duration)))
             sleep_dur = state.sleep_duration if sleep_dur is None else min(sleep_dur, state.sleep_duration)
+            Logger.loginfo("AFTER: sleep_dur={sd}".format(sd=sleep_dur))
         if sleep_dur > 0:
             self._sleep_dur = sleep_dur
 

--- a/flexbe_core/src/flexbe_core/core/concurrency_container.py
+++ b/flexbe_core/src/flexbe_core/core/concurrency_container.py
@@ -49,10 +49,7 @@ class ConcurrencyContainer(OperatableStateMachine):
                     # this sleep returns immediately since sleep duration is negative,
                     # but is required here to reset the sleep time after executing
                     state.sleep()
-
-            Logger.loginfo("BEFORE: state.sleep_duration({ssd}) if sleep_dur({sd}) is None else".format(ssd=state.sleep_duration, sd=sleep_dur))
             sleep_dur = state.sleep_duration if sleep_dur is None else min(sleep_dur, state.sleep_duration)
-            Logger.loginfo("AFTER: sleep_dur={sd}".format(sd=sleep_dur))
         if sleep_dur > 0:
             self._sleep_dur = sleep_dur
 

--- a/flexbe_core/src/flexbe_core/core/concurrency_container.py
+++ b/flexbe_core/src/flexbe_core/core/concurrency_container.py
@@ -50,9 +50,7 @@ class ConcurrencyContainer(OperatableStateMachine):
                     # but is required here to reset the sleep time after executing
                     state.sleep()
 
-            Logger.loginfo("BEFORE: state.sleep_duration({ssd}) if sleep_dur({sd}) is None else "
-                           "min(sleep_dur, state.sleep_duration)({m})"
-                           .format(ssd=state.sleep_duration, sd=sleep_dur, m=min(sleep_dur, state.sleep_duration)))
+            Logger.loginfo("BEFORE: state.sleep_duration({ssd}) if sleep_dur({sd}) is None else".format(ssd=state.sleep_duration, sd=sleep_dur))
             sleep_dur = state.sleep_duration if sleep_dur is None else min(sleep_dur, state.sleep_duration)
             Logger.loginfo("AFTER: sleep_dur={sd}".format(sd=sleep_dur))
         if sleep_dur > 0:

--- a/flexbe_core/test/test_core.py
+++ b/flexbe_core/test/test_core.py
@@ -358,6 +358,7 @@ class TestCore(unittest.TestCase):
         cc.execute(None)
         cc.sleep()
         cc.execute(None)
+        rospy.logwarn("self.assertAlmostEqual(cc.sleep_duration, .1, places=2)")
         self.assertAlmostEqual(cc.sleep_duration, .1, places=2)
         cc.sleep()
         cc['main'].set_rate(15)

--- a/flexbe_core/test/test_core.py
+++ b/flexbe_core/test/test_core.py
@@ -355,13 +355,9 @@ class TestCore(unittest.TestCase):
                 pass
 
         # all states are called with their correct rate
-        self.assertEquals(cc.sleep_duration, 0., msg="cc.sleep_duration should be 0. before executing")
         cc.execute(None)
-        self.assertAlmostEqual(cc.sleep_duration, .1, delta=0.05, msg="After executing once, cc.sleep_duration should be set to the duration of the 'fastest' state")
         cc.sleep()
-        self.assertAlmostEqual(cc.sleep_duration, .0, delta=0.05, msg="After sleeping once, cc.sleep_duration should be reset to 0")
         cc.execute(None)
-        rospy.logwarn("self.assertAlmostEqual(cc.sleep_duration, .1, places=2)")
         self.assertAlmostEqual(cc.sleep_duration, .1, delta=0.05, msg="After executing twice, cc.sleep_duration should be set to the duration of the 'fastest' state")
         cc.sleep()
         cc['main'].set_rate(15)

--- a/flexbe_core/test/test_core.py
+++ b/flexbe_core/test/test_core.py
@@ -355,11 +355,14 @@ class TestCore(unittest.TestCase):
                 pass
 
         # all states are called with their correct rate
+        self.assertEquals(cc.sleep_duration, 0., msg="cc.sleep_duration should be 0. before executing")
         cc.execute(None)
+        self.assertAlmostEqual(cc.sleep_duration, .1, delta=0.05, msg="After executing once, cc.sleep_duration should be set to the duration of the 'fastest' state")
         cc.sleep()
+        self.assertAlmostEqual(cc.sleep_duration, .0, delta=0.05, msg="After sleeping once, cc.sleep_duration should be reset to 0")
         cc.execute(None)
         rospy.logwarn("self.assertAlmostEqual(cc.sleep_duration, .1, places=2)")
-        self.assertAlmostEqual(cc.sleep_duration, .1, places=2)
+        self.assertAlmostEqual(cc.sleep_duration, .1, delta=0.05, msg="After executing twice, cc.sleep_duration should be set to the duration of the 'fastest' state")
         cc.sleep()
         cc['main'].set_rate(15)
         cc['side'].set_rate(10)


### PR DESCRIPTION
We've noticed that sometimes the test for the `ConcurrencyContainer` failed, because the calculated sleep_duration was not accurate enough to satisfy the test but certainly looks correct. 
I think the issue is some rounding or floating point issue, but not sure. 

This PR specifies a maximum deviation `delta` rather than the amount of decimal places.