### PR TITLE
Get sleep_duration of ConcurrencyContainer dynamically

### DIFF
--- a/flexbe_core/src/flexbe_core/core/concurrency_container.py
+++ b/flexbe_core/src/flexbe_core/core/concurrency_container.py
@@ -17,20 +17,20 @@ class ConcurrencyContainer(OperatableStateMachine):
         super(ConcurrencyContainer, self).__init__(*args, **kwargs)
         self._conditions = conditions
         self._returned_outcomes = dict()
-        self._sleep_dur = None
 
     def sleep(self):
-        if self._sleep_dur is not None:
-            self.wait(seconds=self._sleep_dur)
-            self._sleep_dur = None
+        self.wait(seconds=self.sleep_duration)
 
     @property
     def sleep_duration(self):
-        return self._sleep_dur or 0.
+        sleep_dur = None
+        for state in self._states:
+            if state.sleep_duration>0:
+                sleep_dur = state.sleep_duration if sleep_dur is None else min(sleep_dur, state.sleep_duration)
+        return sleep_dur or 0.
 
     def _execute_current_state(self):
         # execute all states that are done with sleeping and determine next sleep duration
-        sleep_dur = None
         for state in self._states:
             if state.name in list(self._returned_outcomes.keys()) and self._returned_outcomes[state.name] is not None:
                 continue  # already done with executing
@@ -49,9 +49,6 @@ class ConcurrencyContainer(OperatableStateMachine):
                     # this sleep returns immediately since sleep duration is negative,
                     # but is required here to reset the sleep time after executing
                     state.sleep()
-            sleep_dur = state.sleep_duration if sleep_dur is None else min(sleep_dur, state.sleep_duration)
-        if sleep_dur > 0:
-            self._sleep_dur = sleep_dur
 
         # Determine outcome
         outcome = None


### PR DESCRIPTION
After updating from version 1.2.5 to 1.3.1 I have observed that running a ConcurrencyContainer inside another ConcurrencyContainer was not possible anymore. 

After debugging I found out that the `sleep_duration` property of the inner ConcurrencyContainer gets written the first time it is executed, but not updated until the `sleep()` method is called. As the outer ConcurrencyContainer check for all its states' `sleep_duration`s in its `_execute_current_state()` method, the inner ConcurrencyContainer appears to always have the same positive `sleep_duration`. Therefore the inner ConcurrencyContainer is always skipped and its `sleep()` method is never called.

In this pull request I have moved the determination of the `sleep_duration` into the `sleep_duration()` method to make it dynamic. 