### PR TITLE
Set _current_state of CC to None on forced exit

### DIFF
--- a/flexbe_core/src/flexbe_core/core/concurrency_container.py
+++ b/flexbe_core/src/flexbe_core/core/concurrency_container.py
@@ -111,3 +111,4 @@ class ConcurrencyContainer(OperatableStateMachine):
             if state in self._returned_outcomes:
                 continue  # skip states that already exited themselves
             self._execute_single_state(state, force_exit=True)
+        self._current_state = None


### PR DESCRIPTION
If a ConcurrencyContainer forces a state to exit that is also a ConcurrencyContainer the latter does not get its `_current_state` parameter set to `None`. 

I realized this after observing that the userdata was not getting reset after the forced exit. In the attachment you can find a simplified example Behavior that helps to recreate the issue.
[test_behavior.zip](https://github.com/team-vigir/flexbe_behavior_engine/files/7184166/test_behavior.zip)
