### PR TITLE
namespace fix for topic lookup with rostopic in subscriber state

### DIFF
--- a/flexbe_core/src/flexbe_core/core/event_state.py
+++ b/flexbe_core/src/flexbe_core/core/event_state.py
@@ -5,7 +5,7 @@ from flexbe_core.core.preemptable_state import PreemptableState
 from flexbe_core.core.priority_container import PriorityContainer
 
 from flexbe_msgs.msg import CommandFeedback
-from std_msgs.msg import Bool, Empty
+from std_msgs.msg import Bool, Empty, String
 
 from flexbe_core.core.operatable_state import OperatableState
 
@@ -24,6 +24,8 @@ class EventState(OperatableState):
         super(EventState, self).__init__(*args, **kwargs)
         self.__execute = self.execute
         self.execute = self._event_execute
+        self.__on_enter = self.on_enter
+        self.on_enter = self._event_on_enter
 
         self._entering = True
         self._skipped = False
@@ -33,6 +35,14 @@ class EventState(OperatableState):
         self._feedback_topic = 'flexbe/command_feedback'
         self._repeat_topic = 'flexbe/command/repeat'
         self._pause_topic = 'flexbe/command/pause'
+        self._update_topic = 'flexbe/behavior_update'
+
+        self._pub.createPublisher(self._update_topic, String)
+
+    def _event_on_enter(self, *args, **kwargs):
+        Logger.loginfo("Enter state " + self.path)
+        self._pub.publish(self._update_topic, String(self.path))
+        self.__on_enter(*args, **kwargs)
 
     def _event_execute(self, *args, **kwargs):
         if self._is_controlled and self._sub.has_msg(self._pause_topic):
@@ -121,12 +131,6 @@ class EventState(OperatableState):
     def on_resume(self, userdata):
         """
         Will be executed each time this state is resumed.
-        """
-        pass
-
-    def on_enter(self, userdata):
-        """
-        Will be executed each time the state is entered from any other state (but not from itself).
         """
         pass
 

--- a/flexbe_states/src/flexbe_states/subscriber_state.py
+++ b/flexbe_states/src/flexbe_states/subscriber_state.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import rospy
 import rostopic
 from flexbe_core import EventState, Logger
 
@@ -53,8 +54,11 @@ class SubscriberState(EventState):
             self._sub.remove_last_msg(self._topic)
 
     def _connect(self):
-        msg_type, msg_topic, _ = rostopic.get_topic_class(self._topic)
-        if msg_topic == self._topic:
+        global_topic = self._topic
+        if global_topic[0] != '/':
+            global_topic = rospy.get_namespace() + global_topic
+        msg_type, msg_topic, _ = rostopic.get_topic_class(global_topic)
+        if msg_topic == global_topic:
             self._sub = ProxySubscriberCached({self._topic: msg_type})
             self._connected = True
             return True


### PR DESCRIPTION
The `SubscriberState` of the flexbe states was wrongly using `rostopic` to lookup relative topic names. It was always assuming topics to be at the root of the global namespace, even when the behavior engine was executed within a sub-namespace.

This is fixed now by assuming 
* topic names given with leading slash to be global names and
* any other names to be relative to the name space in which the behavior engine is running.