### PR TITLE
namespace fix for topic lookup with rostopic in subscriber state

### DIFF
--- a/flexbe_states/src/flexbe_states/subscriber_state.py
+++ b/flexbe_states/src/flexbe_states/subscriber_state.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import rospy
 import rostopic
 from flexbe_core import EventState, Logger
 
@@ -53,8 +54,11 @@ class SubscriberState(EventState):
             self._sub.remove_last_msg(self._topic)
 
     def _connect(self):
-        msg_type, msg_topic, _ = rostopic.get_topic_class(self._topic)
-        if msg_topic == self._topic:
+        global_topic = self._topic
+        if global_topic[0] != '/':
+            global_topic = rospy.get_namespace() + global_topic
+        msg_type, msg_topic, _ = rostopic.get_topic_class(global_topic)
+        if msg_topic == global_topic:
             self._sub = ProxySubscriberCached({self._topic: msg_type})
             self._connected = True
             return True


### PR DESCRIPTION
The `SubscriberState` of the flexbe states was wrongly using `rostopic` to lookup relative topic names. It was always assuming topics to be at the root of the global namespace, even when the behavior engine was executed within a sub-namespace.

This is fixed now by assuming 
* topic names given with leading slash to be global names and
* any other names to be relative to the name space in which the behavior engine is running.

Update for PR https://github.com/team-vigir/flexbe_behavior_engine/pull/155